### PR TITLE
Basic TLS support

### DIFF
--- a/docs/bootstrap/dev-vm.md
+++ b/docs/bootstrap/dev-vm.md
@@ -212,6 +212,7 @@ below in a `start.sh` file and make it executable.
 
 port_fwd='hostfwd=tcp::22-:22,'
 port_fwd+='hostfwd=tcp::80-:80,'
+port_fwd+='hostfwd=tcp::443-:443,'
 port_fwd+='hostfwd=tcp::5432-:5432'
 
 qemu-system-aarch64 \

--- a/nix/modules/service-stack/module.nix
+++ b/nix/modules/service-stack/module.nix
@@ -63,6 +63,17 @@ with types;
         default = "${pkgs.odbox.localhost-cert}/key.pem";
         description = "Path to the server's TLS certificate key.";
       };
+      domain = mkOption {
+        type = str;
+        default = "localhost";
+        description = ''
+          Odoo domain name for Nginx's virtual host.
+          Since we make the Odoo host the default Nginx server, you won't
+          need to set this option unless you'd like to use NixOS's built-in
+          support to automatically get and renew TLS certs, in which case,
+          you should set this option to the FQDN of the host machine.
+        '';
+      };
       bootstrap-mode = mkOption {
         type = bool;
         default = false;
@@ -102,6 +113,7 @@ with types;
     nginx = import ./nginx.nix {
       sslCertificate = config.services.odbox-stack.nginx-cert;
       sslCertificateKey = config.services.odbox-stack.nginx-cert-key;
+      domain = config.services.odbox-stack.domain;             # (1)
     };
   in (mkIf enabled
   {
@@ -139,3 +151,15 @@ with types;
   });
 
 }
+# NOTE
+# ----
+# 1. TLS certs. At the moment we assume the sys admin takes care of
+# getting and renewing TLS certs. But we could automate this step too
+# since NixOS comes with ACME built-in support. In this case, the domain
+# name should be that of the host machine. Also notice that multi-domain
+# configs are also supported.
+# See:
+# - https://nixos.org/manual/nixos/stable/#module-security-acme-nginx
+# - https://nixos.wiki/wiki/Nginx
+# - https://discourse.nixos.org/t/nixos-nginx-acme-ssl-certificates-for-multiple-domains
+#

--- a/nix/modules/service-stack/module.nix
+++ b/nix/modules/service-stack/module.nix
@@ -7,7 +7,7 @@
 # - Odoo addons
 # - Systemd service to run Odoo (including `odoo` sys user)
 # - Non-network Postgres DB backend (Odoo connects on Unix sockets)
-# - Nginx reverse proxy to expose Odoo to the internet
+# - Nginx TLS reverse proxy to expose Odoo to the internet
 #
 # Notice this module comes with a bootstrap option to migrate an Odoo
 # DB and file store from another Odoo server. Also, this module makes
@@ -53,10 +53,15 @@ with types;
         default = 1;
         description = "Number of CPUs available to run the Odoo server.";
       };
-      domain = mkOption {
-        type = str;
-        default = "localhost";
-        description = "Odoo domain name for Nginx config.";
+      nginx-cert = mkOption {
+        type = path;
+        default = "${pkgs.odbox.localhost-cert}/cert.pem";
+        description = "Path to the server's TLS certificate.";
+      };
+      nginx-cert-key = mkOption {
+        type = path;
+        default = "${pkgs.odbox.localhost-cert}/key.pem";
+        description = "Path to the server's TLS certificate key.";
       };
       bootstrap-mode = mkOption {
         type = bool;
@@ -95,7 +100,8 @@ with types;
       bootstrap = config.services.odbox-stack.bootstrap-mode;
     };
     nginx = import ./nginx.nix {
-      domain = config.services.odbox-stack.domain;
+      sslCertificate = config.services.odbox-stack.nginx-cert;
+      sslCertificateKey = config.services.odbox-stack.nginx-cert-key;
     };
   in (mkIf enabled
   {

--- a/nix/modules/service-stack/nginx.nix
+++ b/nix/modules/service-stack/nginx.nix
@@ -1,39 +1,62 @@
 #
 # Generate the NixOS systemd entry for the Nginx service.
-# Tweaked from:
-# - https://github.com/NixOS/nixpkgs/blob/nixos-23.11/nixos/modules/services/finance/odoo.nix
+# We start off with the Nginx SSL example config in the Odoo 14 docs
+# and then bolt on recommended Nginx settings.
+# See:
+# - https://www.odoo.com/documentation/14.0/administration/install/deploy.html#https
 #
-{ domain }:
+{ sslCertificate, sslCertificateKey }:
 {
     enable = true;
+
+    # Configure basic optimisation params.
+    recommendedOptimisation = true;
+
+    # Turn on recommended proxy settings.
+    # These two settings below configure all the headers required for
+    # Odoo proxy mode as well as all the proxy related timeouts as in
+    # in the SSL config example found in the Odoo 14 docs.
+    recommendedProxySettings = true;
+    proxyTimeout = "720s";
+
+    # Ditto for TLS settings.
+    # Notice this option configures all the Nginx SSL settings in the
+    # Odoo example Ngnix config except for certs.
+    recommendedTlsSettings = true;
+
+    # Ditto for Gzip settings.
+    # Notice the Nix config list alot of MIME types to compress. This
+    # list contains all the MIME types in the Odoo config example except
+    # for 'text/scss'. But 'text/scss' ain't a MIME type AFAIK. So we
+    # leave that one out.
+    recommendedGzipSettings = true;
 
     upstreams = {
       odoo.servers = {
         "127.0.0.1:8069" = {};
       };
-
       odoochat.servers = {
         "127.0.0.1:8072" = {};
       };
     };
 
-    virtualHosts."${domain}" = {
-      extraConfig = ''
-        proxy_read_timeout 720s;
-        proxy_connect_timeout 720s;
-        proxy_send_timeout 720s;
+    virtualHosts.proxy = {
+      inherit sslCertificate sslCertificateKey;
 
-        proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
-      '';
+      # Our Odoo stack is supposed to run on a dedicated box. So we
+      # only need this one Nginx server which is why we make it the
+      # the default server.
+      default = true;
+
+      # Redirect (301) plain HTTP traffic on port 80 to HTTPS on port 443.
+      forceSSL = true;
 
       locations = {
+        # Forward long-polling requests to the Odoo gevent server.
         "/longpolling" = {
           proxyPass = "http://odoochat";
         };
-
+        # Forward requests to the Odoo backend server.
         "/" = {
           proxyPass = "http://odoo";
           extraConfig = ''

--- a/nix/modules/service-stack/nginx.nix
+++ b/nix/modules/service-stack/nginx.nix
@@ -5,7 +5,7 @@
 # See:
 # - https://www.odoo.com/documentation/14.0/administration/install/deploy.html#https
 #
-{ sslCertificate, sslCertificateKey }:
+{ sslCertificate, sslCertificateKey, domain }:
 {
     enable = true;
 
@@ -40,7 +40,7 @@
       };
     };
 
-    virtualHosts.proxy = {
+    virtualHosts."${domain}" = {
       inherit sslCertificate sslCertificateKey;
 
       # Our Odoo stack is supposed to run on a dedicated box. So we

--- a/nix/nodes/devm-aarch64/flake.lock
+++ b/nix/nodes/devm-aarch64/flake.lock
@@ -85,12 +85,12 @@
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-YcBXHOIry/gYviDffnonOmLCIvIs2Vc7+LmzYFjl+ro=",
-        "path": "/nix/store/hxrsgivkjv60jc24r8arb16jjy0rsr18-source/nix",
+        "narHash": "sha256-00V9Lx5UUhHGQX8nhhkRC8dEF2B97AmQznYGd9mOluE=",
+        "path": "/nix/store/5k4m2bh1dl4p8w7pknhrmikj3l625gxb-source/nix",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/hxrsgivkjv60jc24r8arb16jjy0rsr18-source/nix",
+        "path": "/nix/store/5k4m2bh1dl4p8w7pknhrmikj3l625gxb-source/nix",
         "type": "path"
       }
     },

--- a/nix/nodes/devm-aarch64/flake.lock
+++ b/nix/nodes/devm-aarch64/flake.lock
@@ -85,12 +85,12 @@
       },
       "locked": {
         "lastModified": 1,
-        "narHash": "sha256-00V9Lx5UUhHGQX8nhhkRC8dEF2B97AmQznYGd9mOluE=",
-        "path": "/nix/store/5k4m2bh1dl4p8w7pknhrmikj3l625gxb-source/nix",
+        "narHash": "sha256-o1dYrpnqlFtnkXy7ha3SH+kSQ8zIv3FbtBDyimbY/kE=",
+        "path": "/nix/store/i8jw3gwyz3rx8sdqrdy9h1xg4sz2x2r4-source/nix",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/5k4m2bh1dl4p8w7pknhrmikj3l625gxb-source/nix",
+        "path": "/nix/store/i8jw3gwyz3rx8sdqrdy9h1xg4sz2x2r4-source/nix",
         "type": "path"
       }
     },

--- a/nix/pkgs/localhost-cert/default.nix
+++ b/nix/pkgs/localhost-cert/default.nix
@@ -1,0 +1,1 @@
+{ pkgs }: pkgs.callPackage ./pkg.nix {}

--- a/nix/pkgs/localhost-cert/pkg.nix
+++ b/nix/pkgs/localhost-cert/pkg.nix
@@ -1,0 +1,41 @@
+#
+# Generate a self-signed, 100-year valid SSL cert for testing on
+# localhost.
+# Put the cert and key in the out dir with file names, `cert.pem`
+# and `key.pem`, respectively.
+#
+{
+  stdenv, libressl
+}:
+let
+  openssl = "${libressl}/bin/openssl";
+in stdenv.mkDerivation {
+    pname = "localhost-cert";
+    version = "1.0.0";
+
+    dontUnpack = true;                                         # (1)
+
+    buildPhase = ''
+      ${openssl} \
+        req -x509 -newkey rsa:4096 \
+        -days 36500 -nodes -subj '/CN=localhost' \
+        -keyout key.pem -out cert.pem
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      mv cert.pem $out/
+      mv key.pem $out/
+    '';                                                       # (2)
+
+}
+# NOTE
+# ----
+# 1. No source. Since we've got no source, the unpack phase would fail
+# if we ran it.
+# See:
+# - https://github.com/NixOS/nixpkgs/issues/23099
+#
+# 2. Security. The cert key will wind up in the Nix store which is
+# world-readable. Only ever use this package for testing on localhost!
+#

--- a/nix/pkgs/localhost-cert/pkg.nix
+++ b/nix/pkgs/localhost-cert/pkg.nix
@@ -39,3 +39,10 @@ in stdenv.mkDerivation {
 # 2. Security. The cert key will wind up in the Nix store which is
 # world-readable. Only ever use this package for testing on localhost!
 #
+# 3. CA. We could improve our setup by creating our own Certificate
+# Authority and then sign our cert with that CA. This way, you could
+# import the CA in e.g. your browser and get rid of the annoying sec
+# warning when hitting localhost:443.
+# See:
+# - https://hackernoon.com/how-to-get-sslhttps-for-localhost-i11s3342
+#

--- a/nix/pkgs/mkSysOutput.nix
+++ b/nix/pkgs/mkSysOutput.nix
@@ -12,6 +12,7 @@ let
   tools = import ./cli-tools { pkgs = sysPkgs; };
   odoo = import ./odoo-14 { pkgs = sysPkgs; };
   addons = import ./odoo-addons { pkgs = sysPkgs; };
+  localhost-cert = import ./localhost-cert { pkgs = sysPkgs; };
 in rec {
   packages.${system} = {
     default = tools.dev-shell;
@@ -19,5 +20,6 @@ in rec {
     linux-admin-shell = tools.linux-admin-shell;
     odoo-14 = odoo;
     odoo-addons = addons;
+    inherit localhost-cert;
   };
 }


### PR DESCRIPTION
This PR implements a basic TLS setup for the Odoo service stack. In detail,

- Nginx gets configured w/ a cert (and corresponding key) of your choice.
- Default self-signed cert for localhost so you can test the TLS setup in our dev VM---you'll have to ignore your browser's warning about the cert though :-)
- Nginx redirects any HTTP traffic on port 80 to HTTPS on port 443.
- Sane Nginx default config.

Notice at the moment we assume the sys admin takes care of getting and renewing TLS certs. But we could automate this step too since NixOS comes with ACME built-in support. Plus, multi-domain configs are also supported.
See:
- https://nixos.org/manual/nixos/stable/#module-security-acme-nginx
- https://nixos.wiki/wiki/Nginx
- https://discourse.nixos.org/t/nixos-nginx-acme-ssl-certificates-for-multiple-domains