### PR TITLE
Fix bootstrap docs

### DIFF
--- a/docs/bootstrap/odoo-data.md
+++ b/docs/bootstrap/odoo-data.md
@@ -100,10 +100,8 @@ NixOS target machine in Odoo bootstrap mode by configuring your
 target's machine Flake with the following expression:
 
 ```nix
-  services.odbox-stack = {
-    enable = true;
-    bootstrap-mode = true;
-  };
+  odbox.server.enable = true;
+  odbox.service-stack.bootstrap-mode = true;
 ```
 
 This way we get the whole Odoo stack up and running except for the
@@ -138,14 +136,16 @@ $ sudo chown odoo:odoo -R /var/lib/odoo/
 ```
 
 At this point the last thing left to do is to reconfigure NixOS
-to run the full Odoo stack:
+to run the full Odoo stack. To do that just delete the `bootstrap-mode`
+option from your config:
 
 ```nix
-  services.odbox-stack = {
-    enable = true;
-    odoo-db-name = "odoo_martel_14";
-  };
+  odbox.server.enable = true;
 ```
 
+Notice we leave the bootstrap option out so the machine starts with
+the Odoo service too. This is because `odbox.service-stack.bootstrap-mode`
+defaults to `false` so if you don't specify it explicitly, it'll
+stay `false`.
 After taking this config live, you should be able to access the
 Odoo Web UI on the target NixOS box from your local machine.

--- a/docs/bootstrap/odoo-data.md
+++ b/docs/bootstrap/odoo-data.md
@@ -124,8 +124,16 @@ $ cd /tmp
 To restore the DB, run
 
 ```bash
+$ sudo -u postgres psql -c 'ALTER USER odoo WITH CREATEDB'
 $ sudo -u odoo psql -d postgres -f odoo-dump.sql
+$ sudo -u postgres psql -c 'ALTER USER odoo WITH NOCREATEDB'
 ```
+
+Notice we first allow the `odoo` user to create a DB since the dump
+file contains a statement to create the Odoo DB. But after restoring
+the DB, we revoke the create-DB permission since we want to run Odoo
+with the smallest possible set of privileges. This also means you
+won't be able to use Odoo's Web UI to create and restore DBs.
 
 To restore the file store, run
 

--- a/nix/nodes/devm-aarch64/configuration.nix
+++ b/nix/nodes/devm-aarch64/configuration.nix
@@ -13,6 +13,7 @@
   system.stateVersion = "23.11";
 
   odbox.server.enable = true;
+  # odbox.service-stack.bootstrap-mode = true;
   odbox.swapfile = {
     enable = true;
     size = 8192;


### PR DESCRIPTION
This PR brings the bootstrap docs up to date:

- the server bootstrap option is now in the right namespace
- the DB restore procedure mentions assigning and revoking the create-DB permission to the Odoo DB user