### PR TITLE
Make Odoo service depend on password file

### DIFF
--- a/nix/modules/service-stack/odoo-svc.nix
+++ b/nix/modules/service-stack/odoo-svc.nix
@@ -55,11 +55,12 @@ let
 in {
   wantedBy = [ "multi-user.target" ];
   after = [ "network.target" "postgresql.service" ];
+  requires = [ "postgresql.service" ];
+  restartTriggers = [ pwd-file ];
 
   # pg_dump
   path = [ postgres-pkg ];
 
-  requires = [ "postgresql.service" ];
   script = run;
 
   serviceConfig = {


### PR DESCRIPTION
This PR tries to fix #10, but to no avail. We add the `restartTriggers` clause to the Odoo system service definition to make the unit depend on the password file. This is a good change anyway so we keep it, but truth be told, it made no difference. Tested #10 scenario both w/ Agez and Agenix.