### PR TITLE
Backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ bit easier:
 - Built-in EC2 Graviton support. One-liner install for `m6g.xlarge`,
   `m6g.2xlarge`, `c6g.xlarge`, `c6g.2xlarge`, and `t4g.2xlarge`
   instance types.
+- Backups. Automatic hot and cold backups with flexible schedules.
+  Notice that thanks to our Nix-powered GitOps approach, backing
+  up and restoring a machine is a breeze. We just need to back up
+  the Odoo DB and file store since our repo contains everything
+  else you need to instantiate our Odoo Box. With a snapshot of
+  the Odoo DB and file store at a point in time, you can restore
+  your machine to the exact same state it was at that point in
+  time with just a couple of commands.
 
 
 ### Development & Testing

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -2,4 +2,48 @@ Backups
 -------
 > Keeping our data for posterity.
 
-**Coming soon**. Watch this space :-)
+
+Thanks to our Nix-powered GitOps approach, backing up and restoring
+a machine is a breeze. Except for the data in the Odoo DB and file
+store, our repo contains everything you need to instantiate our Odoo
+Box. For that reason, all we need to back up is the Odoo DB and file
+store using our backup NixOS module as explained below. If you have
+a snapshot of the Odoo DB and file store at a point in time, you can
+restore your machine to the exact same state it was at that point in
+time with just a couple of commands.
+
+
+### Backing up Odoo data
+
+We've developed a [backup NixOS module][module] to help stash away
+Odoo data. The module automatically extracts both the Odoo DB and
+file store to a directory you choose at regular intervals you can
+also configure. Plus, it lets you take both hot and cold backups.
+A hot backup happens while Odoo is running and, for that reason,
+isn't necessarily going to give you a consistent DB and file store
+state when you restore it. On the other hand, a cold back up will
+give you a consistent state since the module temporarily stops Odoo
+while it's extracting the data. The [module docs][module] explain
+how to enable and configure backups.
+
+
+### Restoring a machine
+
+Restoring a machine to its original state is a no-brainer. All you
+need to do is
+1. Deploy the boot NixOS config. Here you'd use the Flake as it
+   was in the repo at the time the backup was taken.
+2. Pump Odoo data back into the DB by running `psql` on the DB
+   backup file.
+3. Copy over the file store from the backup.
+4. Deploy the prod NixOS config. Here too, you'd use the Flake
+   as it was in the repo at the time the backup was taken.
+
+Basically the same procedure as explained in the *Restoring data*
+section of the [data bootstrap page][data-boot].
+
+
+
+
+[module]: ../nix/modules/backup/docs.md
+[data-boot]: ./bootstrap/odoo-data.md

--- a/nix/modules/backup/default.nix
+++ b/nix/modules/backup/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./interface.nix
+  ];
+}

--- a/nix/modules/backup/default.nix
+++ b/nix/modules/backup/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
     ./interface.nix
+    ./odoo.nix
   ];
 }

--- a/nix/modules/backup/default.nix
+++ b/nix/modules/backup/default.nix
@@ -1,6 +1,6 @@
 {
   imports = [
     ./interface.nix
-    ./odoo.nix
+    ./odoo/module.nix
   ];
 }

--- a/nix/modules/backup/docs.md
+++ b/nix/modules/backup/docs.md
@@ -2,4 +2,170 @@ Backup
 ------
 > Nix module docs.
 
-**TODO**
+This [module][iface] automatically backs up the Odoo DB and file
+store.
+
+
+### Overview
+
+Backups run at configurable intervals and every time a backup fires,
+we dump the Odoo DB into a SQL file (using `pg_dump`) and sync the
+Odoo backup file store with the live file store. All the backup files
+get stored in a configurable backup area. Notice the syncing of the
+file store happens through `rsync` which lets us efficiently mirror
+the live file store as only file blocks that have changed since the
+last backup actually get copied over from the live file store. Also,
+any file deleted in the live store gets automatically deleted from
+the mirror copy too.
+
+Notice each backup run overrides the files of the previous. You have
+to set up an EBS policy to actually take snapshots after each backup
+run. Also, you should compress and encrypt snapshots as we don't do
+that at the moment.
+
+We do both hot and cold backups. The hot backups dump the DB and sync
+the file store while Odoo is running, whereas a cold one stops Odoo
+before backing up and then restarts it as soon as the backup is done.
+Notice that a hot backup may result in an inconsistent DB and file
+store when restored, whereas cold backups are safe to restore.
+
+One last thing to mention is the Odoo sessions clean-up. Since we
+have to stop Odoo before making a cold backup, we take advantage
+of Odoo not running to get rid of any session files still on disk.
+Ideally Odoo should clean up after itself, but that doesn't always
+happen and overtime you could pile up truck loads of stale session
+files which would slow down directory access and in turn slow down
+Odoo itself.
+
+Have a look at these Nix files for the implementation details:
+- [Odoo implementation entry point][odoo-mod]
+- [Odoo backup script][odoo-script]
+- [Odoo hot/cold backup module template][odoo-svc]
+
+
+### Backup area
+
+Backups get written to a configurable directory. You specify where
+this directory should be through the base directory option which
+takes an absolute path—default: `/backup`. Notice the backup module
+automatically assigns permissions so only root can access the backup
+area. It also sets up an `odoo` directory under the base directory
+where it stores all the Odoo backup files. Specifically, the `odoo`
+directory contains the SQL dump file and a `filestore` directory
+which mirrors the live file store contents. Here's an example of
+the backup area contents:
+
+```
+/backup
+└── odoo
+   ├── filestore
+   │  └── odoo_martel_14
+   │     └── ...
+   └── odoo_martel_14.dump.sql
+```
+
+Typically, you'd mount a separate, dedicated disk or partition on
+the backup base directory path. For example, at the moment in prod
+we mount an EBS volume on the backup directory. Even if you don't
+set up a dedicated backup mount, backups will still work since the
+module automatically creates the backup base directory on the root
+file system if no directory exist at the configured backup path.
+This comes in handy for testing with the dev VM where there's no
+separate backup disk or partition.
+
+Notice that the backup module streams data to the backup area. So
+you won't need to cater for double the size of the live data on the
+source partition (where the Odoo data sits) as it'd be the case if
+the backup procedure first wrote all the files to that disk before
+moving them to the backup area.
+
+
+### Schedules
+
+The module provides [options][iface] to schedule both hot and cold
+backups. Typically you'd want to do a hot backup a few times a day
+during business hours. For example: daily at 11AM, 2PM and 4PM. This
+way, even if the backup isn't necessarily consistent when you restore
+it, you've still got enough data to try reassembling the pieces. On
+the other hand, the cold backup is a consistent one, but you wouldn't
+want to run it during business hours as Odoo needs to go down. Likely
+you'd make a cold backup once a day in the dead of the night—e.g.
+daily at 2AM.
+
+Both hot and cold backup options accept a list of schedules. Each
+schedule is a string in systemd time format—see `systemd.time(7)`
+for the details. For each schedule entry you add to the list, the
+module generates a corresponding `OnCalendar` directive in the backup
+systemd unit file. This way you can easily schedule multiple runs in
+an intuitive way, e.g.
+
+```nix
+    [ "11:00:00" "14:00:00" "16:00:00" ]
+```
+
+for three daily runs at 11AM, 2PM and 4PM, instead of using the more
+cryptic
+
+```nix
+    [ "11,14,16:00:00" ]
+```
+
+Notice you can use `systemd-analyze` to check your schedule spec is
+valid and also display the actual schedule systemd will follow, e.g.
+
+```bash
+$ systemd-analyze calendar "11,14,16:00:00" --iterations 9
+  Original form: 11,14,16:00:00
+Normalized form: *-*-* 11,14,16:00:00
+    Next elapse: Wed 2024-05-01 16:00:00 CEST
+       (in UTC): Wed 2024-05-01 14:00:00 UTC
+       From now: 3min 14s left
+   Iteration #2: Thu 2024-05-02 11:00:00 CEST
+       (in UTC): Thu 2024-05-02 09:00:00 UTC
+       From now: 19h left
+   Iteration #3: Thu 2024-05-02 14:00:00 CEST
+       (in UTC): Thu 2024-05-02 12:00:00 UTC
+       From now: 22h left
+   Iteration #4: Thu 2024-05-02 16:00:00 CEST
+       (in UTC): Thu 2024-05-02 14:00:00 UTC
+       From now: 24h left
+   Iteration #5: Fri 2024-05-03 11:00:00 CEST
+       (in UTC): Fri 2024-05-03 09:00:00 UTC
+       From now: 1 day 19h left
+   Iteration #6: Fri 2024-05-03 14:00:00 CEST
+       (in UTC): Fri 2024-05-03 12:00:00 UTC
+       From now: 1 day 22h left
+   Iteration #7: Fri 2024-05-03 16:00:00 CEST
+       (in UTC): Fri 2024-05-03 14:00:00 UTC
+       From now: 2 days left
+   Iteration #8: Sat 2024-05-04 11:00:00 CEST
+       (in UTC): Sat 2024-05-04 09:00:00 UTC
+       From now: 2 days left
+   Iteration #9: Sat 2024-05-04 14:00:00 CEST
+       (in UTC): Sat 2024-05-04 12:00:00 UTC
+       From now: 2 days left
+```
+
+
+### Example usage
+
+```nix
+  odbox = {
+    backup = {
+      basedir = "/backup";
+      odoo = {
+        enable = true;
+        hot-schedule = [ "11:00:00" "14:00:00" "16:00:00" ];
+        cold-schedule = [ "02:00:00" ];
+      };
+    };
+  };
+```
+
+
+
+
+[iface]: ./interface.nix
+[odoo-mod]: ./odoo/module.nix
+[odoo-script]: ./odoo/backup-script.nix
+[odoo-svc]: ./odoo/mksvc.nix

--- a/nix/modules/backup/docs.md
+++ b/nix/modules/backup/docs.md
@@ -1,0 +1,5 @@
+Backup
+------
+> Nix module docs.
+
+**TODO**

--- a/nix/modules/backup/interface.nix
+++ b/nix/modules/backup/interface.nix
@@ -1,0 +1,42 @@
+#
+# See `docs.md` for module documentation.
+#
+{ config, lib, pkgs, ... }:
+
+with lib;
+with types;
+
+{
+  options = {
+    odbox.backup.basedir = mkOption {
+      type = path;
+      default = "/backup";
+      description = ''
+        The base directory where all backup files go.
+      '';
+    };
+    odbox.backup.odoo.enable = mkOption {
+      type = bool;
+      default = false;
+      description = ''
+        Enable it to automatically back up the Odoo DB and file store.
+        Backups get scheduled at regular intervals and every time a
+        backup fires, we dump the Odoo DB into a SQL file and put the
+        file in the `odoo` directory under the backup base directory.
+        We also sync the whole file store from the Odoo live store to
+        a corresponding subdirectory of `odoo`.
+
+        Notice each backup run overrides the files of the previous run.
+        You have to set up an EBS policy to actually take snapshots
+        after each backup run.
+
+        We do both hot and cold backups. The hot backups dump the DB
+        and sync the file store while Odoo is running, whereas a cold
+        one stops Odoo before backing up and then restarts it as soon
+        as the backup is done. Notice that a hot backup may result in
+        an inconsistent DB and file store when restored, whereas cold
+        backups are safe to restore.
+      '';
+    };
+  };
+}

--- a/nix/modules/backup/interface.nix
+++ b/nix/modules/backup/interface.nix
@@ -68,5 +68,18 @@ with types;
             systemd-analyze calendar "11,14,16:00:00" --iterations 9
       '';
     };
+    odbox.backup.odoo.cold-schedule = mkOption {
+      type = listOf str;
+      default = [ "02:00:00" ];
+      description = ''
+        Schedule for the cold Odoo backups, i.e. backups performed
+        while Odoo has been stopped. Typically you'd make a cold
+        backup once a day in the dead of the night. For example:
+        daily at 2AM.
+
+        Each schedule entry is a string in the systemd time format,
+        see systemd.time(7) for the details.
+      '';
+    };
   };
 }

--- a/nix/modules/backup/interface.nix
+++ b/nix/modules/backup/interface.nix
@@ -44,28 +44,10 @@ with types;
       default = [ "11:00:00" "14:00:00" "16:00:00" ];
       description = ''
         Schedule for the hot Odoo backups, i.e. backups performed
-        while Odoo is running. Typically you'd back up a few times
-        daily during business hours. For example: daily at 11AM,
-        2PM and 4PM.
-
-        Each schedule entry is a string in the systemd time format,
-        see systemd.time(7) for the details. For each schedule entry
-        you add to the list, there'll be a corresponding `OnCalendar`
-        directive in the systemd unit file. This way you can easily
-        schedule multiple runs in an intuitive way, e.g.
-
-            hot-schedule = [ "11:00:00" "14:00:00" "16:00:00" ];
-
-        for three daily runs at 11AM, 2PM and 4PM, instead of using
-        the more cryptic
-
-            hot-schedule = [ "11,14,16:00:00" ];
-
-        Notice you can use `systemd-analyze` to check your schedule
-        spec is valid and also display the actual schedule systemd
-        will follow, e.g.
-
-            systemd-analyze calendar "11,14,16:00:00" --iterations 9
+        while Odoo is running. Each schedule entry is a string in
+        the systemd time format and for each entry you add to the
+        list, there'll be a corresponding `OnCalendar` directive
+        in the systemd unit file.
       '';
     };
     odbox.backup.odoo.cold-schedule = mkOption {
@@ -73,12 +55,13 @@ with types;
       default = [ "02:00:00" ];
       description = ''
         Schedule for the cold Odoo backups, i.e. backups performed
-        while Odoo has been stopped. Typically you'd make a cold
-        backup once a day in the dead of the night. For example:
-        daily at 2AM.
+        while Odoo has been stopped. Each schedule entry is a string
+        in the systemd time format and for each entry you add to the
+        list, there'll be a corresponding `OnCalendar` directive in
+        the systemd unit file.
 
-        Each schedule entry is a string in the systemd time format,
-        see systemd.time(7) for the details.
+        Notice the cold backup procedure also cleans up stale Odoo
+        session files.
       '';
     };
   };

--- a/nix/modules/backup/interface.nix
+++ b/nix/modules/backup/interface.nix
@@ -26,9 +26,10 @@ with types;
         We also sync the whole file store from the Odoo live store to
         a corresponding subdirectory of `odoo`.
 
-        Notice each backup run overrides the files of the previous run.
+        Notice each backup run overrides the files of the previous.
         You have to set up an EBS policy to actually take snapshots
-        after each backup run.
+        after each backup run. Also, you should compress and encrypt
+        snapshots as we don't do that at the moment.
 
         We do both hot and cold backups. The hot backups dump the DB
         and sync the file store while Odoo is running, whereas a cold
@@ -36,6 +37,35 @@ with types;
         as the backup is done. Notice that a hot backup may result in
         an inconsistent DB and file store when restored, whereas cold
         backups are safe to restore.
+      '';
+    };
+    odbox.backup.odoo.hot-schedule = mkOption {
+      type = listOf str;
+      default = [ "11:00:00" "14:00:00" "16:00:00" ];
+      description = ''
+        Schedule for the hot Odoo backups, i.e. backups performed
+        while Odoo is running. Typically you'd back up a few times
+        daily during business hours. For example: daily at 11AM,
+        2PM and 4PM.
+
+        Each schedule entry is a string in the systemd time format,
+        see systemd.time(7) for the details. For each schedule entry
+        you add to the list, there'll be a corresponding `OnCalendar`
+        directive in the systemd unit file. This way you can easily
+        schedule multiple runs in an intuitive way, e.g.
+
+            hot-schedule = [ "11:00:00" "14:00:00" "16:00:00" ];
+
+        for three daily runs at 11AM, 2PM and 4PM, instead of using
+        the more cryptic
+
+            hot-schedule = [ "11,14,16:00:00" ];
+
+        Notice you can use `systemd-analyze` to check your schedule
+        spec is valid and also display the actual schedule systemd
+        will follow, e.g.
+
+            systemd-analyze calendar "11,14,16:00:00" --iterations 9
       '';
     };
   };

--- a/nix/modules/backup/odoo.nix
+++ b/nix/modules/backup/odoo.nix
@@ -1,0 +1,66 @@
+#
+# Implementation of the Odoo backup functionality declared in the
+# interface.
+# We set up systemd timers and services to run hot and cold backups.
+# We use `pg_dump` to extract DB defs and data, whereas `rsync` takes
+# care of syncing the file store to the backup area.
+#
+{ config, lib, pkgs, ... }:
+
+with lib;
+with types;
+
+{
+
+  config = let
+    # Feature flag.
+    enabled = config.odbox.backup.odoo.enable;
+
+    # User, DB names and schedules.
+    odoo-usr = config.odbox.service-stack.odoo-username;
+    odoo-db = config.odbox.service-stack.odoo-db-name;
+    hot-schedule = config.odbox.backup.odoo.hot-schedule;
+
+    # Packages.
+    sudo = pkgs.sudo;
+    postgres = config.services.postgresql.package;
+    rsync = pkgs.rsync;
+
+    # Backup sources and targets.
+    dst-basedir = "${config.odbox.backup.basedir}/odoo";
+    src-filestore = "/var/lib/${odoo-usr}/data/filestore";
+    dst-db-dump = "${dst-basedir}/${odoo-db}.dump.sql";
+
+  in (mkIf enabled
+  {
+    systemd.services.odoo-hot-backup = {
+      description = "Odoo DB and filestore hot backup to ${dst-basedir}";
+
+      requires = [ "postgresql.service" ];
+
+      path = [ sudo postgres rsync ];
+
+      script = ''
+        umask 0077    # ensure only root can access backup files
+
+        mkdir -p '${dst-basedir}'
+
+        rm -f '${dst-db-dump}'
+        sudo -u '${odoo-usr}' \
+          pg_dump -U '${odoo-usr}' -O -n public '${odoo-db}' \
+                  > '${dst-db-dump}'
+
+        rsync -av --delete '${src-filestore}' '${dst-basedir}/'
+      '';
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = "root";
+      };
+
+      startAt = hot-schedule;
+    };
+
+  });
+
+}

--- a/nix/modules/backup/odoo/backup-script.nix
+++ b/nix/modules/backup/odoo/backup-script.nix
@@ -1,0 +1,37 @@
+#
+# Make the Bash backup script.
+#
+{
+  # The name of the Odoo user.
+  odoo-usr,
+  # The name of the Odoo DB.
+  odoo-db,
+  # Absolute path to the backup base dir.
+  basedir
+}:
+let
+  dst-basedir = "${basedir}/odoo";
+  src-filestore = "/var/lib/${odoo-usr}/data/filestore";
+  dst-db-dump = "${dst-basedir}/${odoo-db}.dump.sql";
+in ''
+  umask 0077
+
+  mkdir -p '${dst-basedir}'
+
+  rm -f '${dst-db-dump}'
+  sudo -u '${odoo-usr}' \
+      pg_dump -U '${odoo-usr}' -O -n public '${odoo-db}' \
+          > '${dst-db-dump}'
+
+  rsync -av --delete '${src-filestore}' '${dst-basedir}/'
+''
+# NOTE
+# ----
+# 1. File perms. We `umask` w/ `0077` to make sure that only the
+# user who runs this script can access the backup files. (Typically
+# the user is root.)
+# 2. DB dump. Notice we extract the dump under the Odoo user but
+# then the actual dump file in the backup dir ends up being owned
+# by the user who runs the script, typically root. So the `umask`
+# in (1) also applies to the dump file.
+#

--- a/nix/modules/backup/odoo/backup-script.nix
+++ b/nix/modules/backup/odoo/backup-script.nix
@@ -7,11 +7,14 @@
   # The name of the Odoo DB.
   odoo-db,
   # Absolute path to the backup base dir.
-  basedir
+  basedir,
+  # Delete all Odoo sessions stored on disk?
+  clean-sessions ? false
 }:
 let
   dst-basedir = "${basedir}/odoo";
   src-filestore = "/var/lib/${odoo-usr}/data/filestore";
+  src-sessions = "/var/lib/${odoo-usr}/data/sessions";
   dst-db-dump = "${dst-basedir}/${odoo-db}.dump.sql";
 in ''
   umask 0077
@@ -24,6 +27,8 @@ in ''
           > '${dst-db-dump}'
 
   rsync -av --delete '${src-filestore}' '${dst-basedir}/'
+
+  ${if clean-sessions then "rm -rf '${src-sessions}'" else ""}
 ''
 # NOTE
 # ----
@@ -34,4 +39,5 @@ in ''
 # then the actual dump file in the backup dir ends up being owned
 # by the user who runs the script, typically root. So the `umask`
 # in (1) also applies to the dump file.
+# 3. Sessions dir. We zap it as Odoo will recreate it automatically.
 #

--- a/nix/modules/backup/odoo/mksvc.nix
+++ b/nix/modules/backup/odoo/mksvc.nix
@@ -1,0 +1,53 @@
+#
+# Make the systemd service entry for hot and cold backups.
+#
+{ config, pkgs, hot ? true }:
+let
+  # User, DB, service names and schedules.
+  odoo-usr = config.odbox.service-stack.odoo-username;
+  odoo-db = config.odbox.service-stack.odoo-db-name;
+  odoo-svc = odoo-usr;                                         # (1)
+  schedule = if hot
+             then config.odbox.backup.odoo.hot-schedule
+             else config.odbox.backup.odoo.cold-schedule;
+
+  # Packages.
+  sudo = pkgs.sudo;
+  postgres = config.services.postgresql.package;
+  rsync = pkgs.rsync;
+
+  # Backup type and base dir.
+  basedir = config.odbox.backup.basedir;
+  kind = if hot then "hot" else "cold";
+in {
+  description = "Odoo DB and file store ${kind} backup to ${basedir}";
+
+  requires = [ "postgresql.service" ];
+
+  path = [ sudo postgres rsync ];
+
+  preStart = if hot
+             then ""
+             else "systemctl stop ${odoo-svc}";
+
+  script = import ./backup-script.nix {
+    inherit odoo-usr odoo-db basedir;
+    clean-sessions = !hot;
+  };
+
+  postStop = if hot
+             then ""
+             else "systemctl start ${odoo-svc}";
+
+  serviceConfig = {
+    Type = "oneshot";
+    User = "root";
+  };
+
+  startAt = schedule;
+}
+# NOTE
+# ----
+# 1. Odoo service name. The service stack module makes the Odoo service
+# name the same as the username specified through the module's interface
+# option.

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./backup
     ./login
     ./os-base.nix
     ./server-base.nix

--- a/nix/nodes/devm-aarch64/configuration.nix
+++ b/nix/nodes/devm-aarch64/configuration.nix
@@ -18,6 +18,7 @@
   odbox = {
     server.enable = true;
     login.mode = "standard";    # NOTE (3)
+
     vault = {
       snakeoil.enable = true;
 
@@ -37,6 +38,16 @@
       # root-ssh-file = ./vault/ssh/id_ed25519.pub;
       # admin-ssh-file = ./vault/ssh/id_ed25519.pub;
     };
+
+    backup = {
+      basedir = "/backup";
+      odoo = {
+        enable = false;                                        # (4)
+        hot-schedule = [ "14:50:00" ];
+        cold-schedule = [ "14:57:00" ];
+      };
+    };
+
     swapfile = {
       enable = true;
       size = 8192;
@@ -51,4 +62,6 @@
 # *Vault and Login Configs* docs.
 # 3. Testing cloud login. See the *Cloud Login* section of the
 # *Vault and Login Configs* docs.
+# 4. Testing backups. Set the schedules you like and then enable
+# the feature. Check service logs and backup dir after each run.
 #


### PR DESCRIPTION
This PR implements automatic hot and cold backups with flexible schedules.
 
Backups run at configurable intervals and every time a backup fires, we dump the Odoo DB into a SQL file (using `pg_dump`) and sync the Odoo backup file store with the live file store. All the backup files get stored in a configurable backup area. Notice the syncing of the file store happens through `rsync` which lets us efficiently mirror the live file store as only file blocks that have changed since the last backup actually get copied over from the live file store. Also, any file deleted in the live store gets automatically deleted from the mirror copy too.

We do both hot and cold backups. The hot backups dump the DB and sync the file store while Odoo is running, whereas a cold one stops Odoo before backing up and then restarts it as soon as the backup is done. Notice that a hot backup may result in an inconsistent DB and file store when restored, whereas cold backups are safe to restore.

One last thing to mention is the Odoo sessions clean-up. Since we have to stop Odoo before making a cold backup, we take advantage of Odoo not running to get rid of any session files still on disk. Ideally Odoo should clean up after itself, but that doesn't always happen and overtime you could pile up truck loads of stale session files which would slow down directory access and in turn slow down Odoo itself.