### PR TITLE
Odoo session reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ the main features, read up about the details in the [docs][docs].
 
 A fully-fledged, multi-architecture (x86-64 and ARM64) service stack
 to run Odoo on a single machine:
-- Odoo multi-processing server, including LiveChat gevent process.
+- Odoo multi-processing server, including LiveChat gevent process
+  and configurable user session timeout.
 - Sane, automatically generated Odoo config.
 - Nix-packaged Odoo addons.
 - systemd service to run Odoo, including daemon user and secure

--- a/nix/modules/service-stack/docs.md
+++ b/nix/modules/service-stack/docs.md
@@ -9,7 +9,8 @@ Service stack to run Odoo.
 
 This [module][iface] configures a fully-fledged service stack to run
 Odoo on a single machine:
-- Odoo multi-processing server, including LiveChat gevent process.
+- Odoo multi-processing server, including LiveChat gevent process
+  and configurable user session timeout.
 - Sane, automatically generated Odoo [config][cfg].
 - Odoo [addons][addons].
 - [Systemd service][svc] to run Odoo, including daemon user and
@@ -67,6 +68,29 @@ odbox.service-stack = {
 
   # optionally
   pgadmin-enable = true;
+};
+```
+
+
+### Session timeout
+
+You can configure a Odoo user session timeout. This is a positive
+number of minutes `M` that determines how long a logged-in user is
+allowed to be inactive before they're automatically logged out. If
+the user's browser hasn't sent a request to the Odoo server in `M`
+minutes, the user session gets deleted and the user is forced to
+log in again.
+
+The default session timeout is 5 minutes. To change it, use the
+`odoo-session-timeout` option as in the example below where we set
+a timeout of 14 days. (This is just an example to show you can use
+a Nix expression to compute the value; in real life probably you
+wouldn't want a 14-day timeout, unless security isn't a concern.)
+
+```nix
+odbox.service-stack = {
+  odoo-session-timeout = 14 * 24 * 60;
+  # ...other options
 };
 ```
 

--- a/nix/modules/service-stack/interface.nix
+++ b/nix/modules/service-stack/interface.nix
@@ -86,6 +86,15 @@ with types;
         default = 1;
         description = "Number of CPUs available to run the Odoo server.";
       };
+      odoo-session-timeout = mkOption {
+        type = ints.positive;
+        default =  5;
+        description = ''
+          Login session timeout in minutes. Any session inactive for longer
+          than these many minutes gets deleted and the user is forced to log
+          in again.
+        '';
+      };
       pgadmin-enable = mkOption {
         type = bool;
         default = false;

--- a/nix/modules/service-stack/odoo-sesh-reaper.nix
+++ b/nix/modules/service-stack/odoo-sesh-reaper.nix
@@ -19,10 +19,8 @@ let
   '';                                                          # (3)
   schedule = [ "*-*-* *:00:00" ];
 in {
-  description = ''
-    Odoo session reaper deletes sessions that have been inactive for
-    longer than ${mins} mins.
-  '';
+  description = "Odoo session reaper deletes sessions that have been "
+              + "inactive for longer than ${mins} mins.";
 
   wantedBy = [ "multi-user.target" ];
 
@@ -39,41 +37,15 @@ in {
 }
 # NOTE
 # ----
-# 1. Odoo session lifecycle. When you hit Odoo w/o having logged in,
-# you get a 90-day-valid anon session cookie `a` which you can only
-# really use to access the login page and download pub assets like
-# images and CSS. There's a corresponding serialised session state
-# `s(a)` Odoo stores under `data/sessions`.
-# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1456
-# If you don't log in, `s(a)` doesn't get deleted until the session
-# GC procedure kicks in, which is the next time someone logs in after
-# one week:
-# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1152
-# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1372
-# But if you log in, you get a 90-day-valid authenticated session
-# cookie `c` and a corresponding serialised session `s(c)` whereas
-# `s(a)` gets deleted. When you log out, Odoo deletes `s(c)` but it
-# redirects you to the login page, so you get a fresh anon cookie `a'`
-# and session state `s(a')`. So the session dir will fill up w/ junk
-# over time. If you don't log out and just close the browser window,
-# you'll still be able to use your cookie `c` for at least a week as
-# inactive sessions are garbage-collected on a weekly-basis:
-# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1152
-# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1372
+# 1. Odoo session lifecycle.
+# See:
+# - https://github.com/c0c0n3/odoo.box/pull/25#issuecomment-2152662861
 #
-# 2. Disabling Odoo session GC. Turns out you can stop Odoo from
-# deleting inactive sessions after a week:
-# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1164-L1169
-# This means session can last as long as 90 days. Of course, you'll
-# have to clean up stale sessions yourself, but that we'd have to do
-# anyway since Odoo seems to leak session state, so even with the GC
-# procedure in place, you could wind up with one gazillion files in
-# `data/sessions`. Too many files in there also means slow directory
-# access which in turn means Odoo slows down too since it has to check
-# session state on each call.
+# 2. Disabling Odoo session GC.
+# See:
+# - https://github.com/c0c0n3/odoo.box/pull/25#issuecomment-2152662861
 #
-# 3. Inactive sessions. Every time you hit Odoo with a valid session
-# cookie `c`, the corresponding serialised session state `s(c)` gets
-# updated. This means we've got an easy way to figure out how long a
-# session has been inactive: just look at the last-modified file attr
-# of `s(c)`.
+# 3. Inactive sessions.
+# See:
+# - https://github.com/c0c0n3/odoo.box/pull/25#issuecomment-2152662861
+#

--- a/nix/modules/service-stack/odoo-sesh-reaper.nix
+++ b/nix/modules/service-stack/odoo-sesh-reaper.nix
@@ -1,0 +1,79 @@
+#
+# Grimly scythe inactive Odoo sessions.
+#
+# This service deletes any Odoo session that's been inactive for
+# longer than the given number of minutes. This service runs every
+# hour on the hour.
+#
+{
+  # Odoo system username.
+  odoo-usr,
+  # Sessions inactive for longer than these many minutes get deleted.
+  older-than
+}:
+let
+  session-dir = "$STATE_DIRECTORY/data/sessions";
+  mins = toString older-than;
+  run = ''
+    find "${session-dir}" -type f -mmin +${mins} -exec rm -f {} +
+  '';                                                          # (3)
+  schedule = [ "*-*-* *:00:00" ];
+in {
+  description = ''
+    Odoo session reaper deletes sessions that have been inactive for
+    longer than ${mins} mins.
+  '';
+
+  wantedBy = [ "multi-user.target" ];
+
+  script = run;
+
+  serviceConfig = {
+    Type = "oneshot";
+    DynamicUser = true;
+    User = odoo-usr;
+    StateDirectory = odoo-usr;
+  };
+
+  startAt = schedule;
+}
+# NOTE
+# ----
+# 1. Odoo session lifecycle. When you hit Odoo w/o having logged in,
+# you get a 90-day-valid anon session cookie `a` which you can only
+# really use to access the login page and download pub assets like
+# images and CSS. There's a corresponding serialised session state
+# `s(a)` Odoo stores under `data/sessions`.
+# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1456
+# If you don't log in, `s(a)` doesn't get deleted until the session
+# GC procedure kicks in, which is the next time someone logs in after
+# one week:
+# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1152
+# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1372
+# But if you log in, you get a 90-day-valid authenticated session
+# cookie `c` and a corresponding serialised session `s(c)` whereas
+# `s(a)` gets deleted. When you log out, Odoo deletes `s(c)` but it
+# redirects you to the login page, so you get a fresh anon cookie `a'`
+# and session state `s(a')`. So the session dir will fill up w/ junk
+# over time. If you don't log out and just close the browser window,
+# you'll still be able to use your cookie `c` for at least a week as
+# inactive sessions are garbage-collected on a weekly-basis:
+# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1152
+# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1372
+#
+# 2. Disabling Odoo session GC. Turns out you can stop Odoo from
+# deleting inactive sessions after a week:
+# - https://github.com/odoo/odoo/blob/tmp.14.0/odoo/http.py#L1164-L1169
+# This means session can last as long as 90 days. Of course, you'll
+# have to clean up stale sessions yourself, but that we'd have to do
+# anyway since Odoo seems to leak session state, so even with the GC
+# procedure in place, you could wind up with one gazillion files in
+# `data/sessions`. Too many files in there also means slow directory
+# access which in turn means Odoo slows down too since it has to check
+# session state on each call.
+#
+# 3. Inactive sessions. Every time you hit Odoo with a valid session
+# cookie `c`, the corresponding serialised session state `s(c)` gets
+# updated. This means we've got an easy way to figure out how long a
+# session has been inactive: just look at the last-modified file attr
+# of `s(c)`.

--- a/nix/modules/service-stack/odoo-svc.nix
+++ b/nix/modules/service-stack/odoo-svc.nix
@@ -58,8 +58,11 @@ in {
   requires = [ "postgresql.service" ];
   restartTriggers = [ pwd-file ];
 
-  # pg_dump
+  # Make `pg_dump` available and disable session GC.
   path = [ postgres-pkg ];
+  environment = {
+    ODOO_DISABLE_SESSION_GC = "1";                             # (1), (2)
+  };
 
   script = run;
 
@@ -69,3 +72,14 @@ in {
     StateDirectory = odoo-usr;
   };
 }
+# NOTE
+# ----
+# 1. Disabling Odoo session GC.
+# See:
+# - https://github.com/c0c0n3/odoo.box/pull/25#issuecomment-2152662861
+#
+# 2. Session reaper. We disable session GC b/c we've got our own service
+# to get rid of inactive and junk sessions.
+# See:
+# - ./odoo-sesh-reaper.nix
+#

--- a/nix/nodes/ec2-aarch64/configuration.nix
+++ b/nix/nodes/ec2-aarch64/configuration.nix
@@ -44,6 +44,7 @@ in {
       autocerts = true;
       domain = "test-odoo.martel-innovate.com";
       odoo-cpus = 4;
+      odoo-session-timeout = 14 * 24 * 60;
     };
     swapfile = {
       enable = true;

--- a/nix/nodes/ec2-x86_64/configuration.nix
+++ b/nix/nodes/ec2-x86_64/configuration.nix
@@ -43,6 +43,7 @@ in {
       autocerts = true;
       domain = "test-odoo.martel-innovate.com";
       odoo-cpus = 2;
+      odoo-session-timeout = 14 * 24 * 60;
     };
     swapfile = {
       enable = true;


### PR DESCRIPTION
This PR implements Odoo session management. In detail,

- We disable Odoo's built-in session garbage-collection.
- We implement a service to delete any Odoo session that's been inactive for longer than a configurable number of minutes. This service runs every hour on the hour.